### PR TITLE
Pause dev

### DIFF
--- a/cpp/data/frameProcessor/include/XspressProcessPlugin.h
+++ b/cpp/data/frameProcessor/include/XspressProcessPlugin.h
@@ -85,6 +85,7 @@ private:
         uint32_t current_block_start_;
         uint32_t concurrent_processes_;
         uint32_t concurrent_rank_;
+        uint32_t offset;
         std::string acq_id_;
         std::string live_view_name_;
 
@@ -115,6 +116,8 @@ private:
         static const std::string CONFIG_DTC_PARAMS;
         
         static const std::string CONFIG_CHUNK;
+
+        static const std::string CONFIG_OFFSET;
 
         /** Pointer to logger */
         LoggerPtr logger_;

--- a/cpp/data/frameProcessor/src/XspressProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/XspressProcessPlugin.cpp
@@ -223,14 +223,14 @@ void XspressProcessPlugin::configure(OdinData::IpcMessage& config, OdinData::Ipc
                         boost::to_string(this->frames_per_block_),
                         buffer.GetString());
 
-      LOG4CXX_INFO(logger_, "Number of frames per block set to " << this->frames_per_block_);
-    }
+    LOG4CXX_INFO(logger_, "Number of frames per block set to " << this->frames_per_block_);
+  }
 
-    if(config.has_param(XspressProcessPlugin::CONFIG_OFFSET))
-    {
-      this->offset = config.get_param<uint32_t>(XspressProcessPlugin::CONFIG_OFFSET);
-      LOG4CXX_INFO(logger_,"configured offset: " << offset);
-    }
+  if(config.has_param(XspressProcessPlugin::CONFIG_OFFSET))
+  {
+    this->offset = config.get_param<uint32_t>(XspressProcessPlugin::CONFIG_OFFSET);
+    LOG4CXX_INFO(logger_,"configured offset: " << offset);
+  }
 
   // Check for the live view plugin name
   if (config.has_param(XspressProcessPlugin::CONFIG_LIVE_VIEW_NAME)) {

--- a/cpp/data/frameProcessor/src/XspressProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/XspressProcessPlugin.cpp
@@ -250,6 +250,7 @@ void XspressProcessPlugin::requestConfiguration(OdinData::IpcMessage& reply)
                   XspressProcessPlugin::CONFIG_PROCESS_RANK, this->concurrent_rank_);
   reply.set_param(get_name() + "/" + XspressProcessPlugin::CONFIG_ACQ_ID, this->acq_id_);
   reply.set_param(get_name() + "/" + XspressProcessPlugin::CONFIG_LIVE_VIEW_NAME, this->live_view_name_);
+  reply.set_param(get_name() + "/" + XspressProcessPlugin::CONFIG_OFFSET, this->offset);
 }
 
 /**

--- a/cpp/data/frameProcessor/src/XspressProcessPlugin.cpp
+++ b/cpp/data/frameProcessor/src/XspressProcessPlugin.cpp
@@ -27,9 +27,9 @@ const std::string XspressProcessPlugin::CONFIG_FRAMES               = "frames";
 const std::string XspressProcessPlugin::CONFIG_DTC_FLAGS            = "dtc/flags";
 const std::string XspressProcessPlugin::CONFIG_DTC_PARAMS           = "dtc/params";
 
-  const std::string XspressProcessPlugin::CONFIG_CHUNK = "chunks";
+const std::string XspressProcessPlugin::CONFIG_CHUNK = "chunks";
 
-  const std::string XspressProcessPlugin::CONFIG_OFFSET = "offset";
+const std::string XspressProcessPlugin::CONFIG_OFFSET = "offset";
 
 const std::string META_NAME = "xspress";
 const std::string META_XSPRESS_CHUNK = "xspress_meta_chunk";
@@ -141,7 +141,7 @@ XspressProcessPlugin::XspressProcessPlugin() :
   dtc_memblock_(0),
   inp_est_memblock_(0),
   num_scalars_recorded_(0),
-                                                 offset(0)
+  offset(0)
 {
   // Setup logging for the class
   logger_ = Logger::getLogger("FP.XspressProcessPlugin");
@@ -229,7 +229,7 @@ void XspressProcessPlugin::configure(OdinData::IpcMessage& config, OdinData::Ipc
     if(config.has_param(XspressProcessPlugin::CONFIG_OFFSET))
     {
       this->offset = config.get_param<uint32_t>(XspressProcessPlugin::CONFIG_OFFSET);
-      LOG4CXX_INFO(logger_,"\n\nconfigured offset: " << offset << "\n\n");
+      LOG4CXX_INFO(logger_,"configured offset: " << offset);
     }
 
   // Check for the live view plugin name
@@ -510,12 +510,12 @@ void XspressProcessPlugin::process_frame(boost::shared_ptr <Frame> frame)
   }
 }
 
-  void XspressProcessPlugin::send_scalars(uint32_t last_frame_id, uint32_t num_scalars, uint32_t first_channel, uint32_t num_channels)
-  {
-    uint32_t num_scalar_values = num_scalars * num_channels;
-    uint32_t num_dtc_factors = num_channels;
-    uint32_t num_inp_est = num_channels;
-    uint32_t frame_id = (last_frame_id - num_scalars_recorded_ + 1)  + (this->offset * this->frames_per_block_); //Acquisition frame ID + Offset
+void XspressProcessPlugin::send_scalars(uint32_t last_frame_id, uint32_t num_scalars, uint32_t first_channel, uint32_t num_channels)
+{
+  uint32_t num_scalar_values = num_scalars * num_channels;
+  uint32_t num_dtc_factors = num_channels;
+  uint32_t num_inp_est = num_channels;
+  uint32_t frame_id = (last_frame_id - num_scalars_recorded_ + 1)  + (this->offset * this->frames_per_block_); //Acquisition frame ID + Offset
 
   rapidjson::Document meta_document;
   meta_document.SetObject();

--- a/python/src/xspress_detector/control/fp_xspress_adapter.py
+++ b/python/src/xspress_detector/control/fp_xspress_adapter.py
@@ -81,6 +81,9 @@ class FPXspressAdapter(FPCompressionAdapter):
     def put(self, path, request):  # pylint: disable=W0613
         if path.startswith("config/hdf/dataset/data"):
             self.configure_data_datasets(path,request)
+        if path.startswith("config/offset/offset_adjustment"):
+            value = json_decode(request.body)
+            self.configure_dataset_offset(value)
         if path == self._command:
             # Check the mode we are running in (mca or list)
             mode = self._xsp_adapter.detector.mode
@@ -170,6 +173,20 @@ class FPXspressAdapter(FPCompressionAdapter):
                         "chunks": int(self._batch_size),
                     },
                     "xspress-list": {"reset": True},
+                }
+                logging.warning("Sending: {}".format(parameters))
+                client.send_configuration(parameters)
+            except Exception as err:
+                logging.debug(OdinDataAdapter.ERROR_FAILED_TO_SEND)
+                logging.error("Error: %s", err)
+
+    def configure_dataset_offset(self, offset):
+        for client in self._clients:
+            try:
+                parameters = {
+                    "xspress": {
+                        "offset": int(offset),
+                    },
                 }
                 logging.warning("Sending: {}".format(parameters))
                 client.send_configuration(parameters)


### PR DESCRIPTION
Adding the option for the Frame Processor Plugin to accept the offset defined by the OffsetPlugin (from odin-data) so that during a scan pause we can offset the frames received after the event by the correct value.